### PR TITLE
Rename Android references to AOS

### DIFF
--- a/.github/actions/common/build/maui/aos/action.yml
+++ b/.github/actions/common/build/maui/aos/action.yml
@@ -1,5 +1,5 @@
-name: Build Maui Android Platform
-description: MAUI Android Platform 빌드하는 작업
+name: Build Maui AOS Platform
+description: MAUI AOS Platform 빌드하는 작업
 
 inputs:
   work_dir:
@@ -30,7 +30,7 @@ runs:
       run: dotnet restore ${{ inputs.work_dir }}/${{ inputs.project_name }}/${{ inputs.project_name }}.csproj
       shell: powershell
 
-    - name: Build MAUI Android project
+    - name: Build MAUI AOS project
       run: |
         dotnet build ${{ inputs.work_dir }}/${{ inputs.project_name }}/${{ inputs.project_name }}.csproj `
           -c ${{ inputs.build_configuration }} `

--- a/.github/workflows/common-build-and-upload-maui-aos-aws-s3.yml
+++ b/.github/workflows/common-build-and-upload-maui-aos-aws-s3.yml
@@ -1,4 +1,4 @@
-name: Build Maui Android Platform And Upload to AWS S3
+name: Build Maui AOS Platform And Upload to AWS S3
 
 on:
   workflow_call:
@@ -88,8 +88,8 @@ jobs:
             aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ inputs.aws_region }}
 
-      - name: Build Maui Android Platform
-        uses: Cream2025/workflow-kit/.github/actions/common/build/maui/android@main
+      - name: Build Maui AOS Platform
+        uses: Cream2025/workflow-kit/.github/actions/common/build/maui/aos@main
         with:
           work_dir: ${{ inputs.work_dir }}
           project_name: ${{ inputs.project_name }}


### PR DESCRIPTION
## Summary
- rename Android build action directory to `aos`
- update action contents to use AOS naming
- update AOS workflow to reference renamed action and adjust text

## Testing
- `grep -R "android" -n --exclude-dir=.git || true`


------
https://chatgpt.com/codex/tasks/task_b_68557d30515c83318a38394892923b79